### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -42,9 +42,8 @@ $(function(){
       })
     });
   
-    if (window.location.href.match(/\/groups\/\d+\/messages/)){
-        var reloadMessages = function(){
-        
+    var reloadMessages = function(){
+      if (window.location.href.match(/\/groups\/\d+\/messages/)){
         var last_message_id = $('.message:last').data('message-id');
         $.ajax({
           url: 'api/messages',
@@ -65,8 +64,8 @@ $(function(){
         .fail(function(){
           alert('メッセージの更新に失敗しました');
         }); 
-      };
-      setInterval(reloadMessages,5000);
-    }
+      }
+    };
+    setInterval(reloadMessages,5000);   
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message) {
     var content = message.content? `${ message.content }` : "";
     var img = message.image? `<img src= ${message.image}>`: "";
-    var html = `<div class="message" data-id="${ message.id }"
+    var html = `<div class="message" data-message-id="${ message.id }"
                 <div class="message-info">
                   <p class="message-info__user-name">
                     ${ message.user_name }
@@ -41,28 +41,32 @@ $(function(){
         alert('メッセージ送信に失敗しました。')
       })
     });
-
-    var reloadMessages = function(){
-      var last_message_id = $('.message').last().data("message-id");
-
-      $.ajax({
-        url: "api/messages",
-        type: 'get',
-        dataType: 'json',
-        data: {last_id: last_message_id};
-      })
-
-      .done(function(messages){
-        var insertHTML = '';
-        messages.forEach(function(message){
-          insertHTML = buildHTML(message);
-          $('.messages').append(insertHTML);
+  
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+        var reloadMessages = function(){
+        
+        var last_message_id = $('.message:last').data('message-id');
+        $.ajax({
+          url: 'api/messages',
+          type: 'get',
+          dataType: 'json',
+          data: {last_id: last_message_id}
         })
-      })
 
-      .fail(function(){
-        alert('メッセージの更新に失敗しました');
-      })
+        .done(function(messages){
+          var insertHTML = '';
+          messages.forEach(function(message){
+            insertHTML = buildHTML(message);
+            $('.messages').append(insertHTML);
+          })
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight},'fast');
+        })
+
+        .fail(function(){
+          alert('メッセージの更新に失敗しました');
+        }); 
+      };
+      setInterval(reloadMessages,5000);
     }
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -41,5 +41,28 @@ $(function(){
         alert('メッセージ送信に失敗しました。')
       })
     });
+
+    var reloadMessages = function(){
+      var last_message_id = $('.message').last().data("message-id");
+
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {last_id: last_message_id};
+      })
+
+      .done(function(messages){
+        var insertHTML = '';
+        messages.forEach(function(message){
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+        })
+      })
+
+      .fail(function(){
+        alert('メッセージの更新に失敗しました');
+      })
+    }
   });
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,4 @@
+class Api::MessagesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,6 +1,6 @@
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
-    @messages = @group.messages.includes(:user).where('id > ?',params[:last_id])
+    @messages = @group.messages.includes(:user).where('id > ?', params[:last_id])
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,4 +1,6 @@
 class Api::MessagesController < ApplicationController
   def index
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user).where('id > ?',params[:last_id])
   end
 end

--- a/app/views/api/index.json.jbuilder
+++ b/app/views/api/index.json.jbuilder
@@ -1,7 +1,0 @@
-json.array! @messages do
-  json.content message.content
-  json.image message.image
-  json.created_at message.created_at
-  json.user_name message.user.name 
-  json.id message.id
-end

--- a/app/views/api/index.json.jbuilder
+++ b/app/views/api/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name 
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name 
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .message-info
     .message-info__user-name
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message({"data-message-id": "#{message.id}"}/)
   .message-info
     .message-info__user-name
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message({"data-message-id": "#{message.id}"}/)
+.message
   .message-info
     .message-info__user-name
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only:[:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
チャット画面の自動更新機能を実装する

# Why 
チャットアプリとしての利便性を高めるため
（メッセージ確認のためにユーザーが逐一ブラウザをリロードする手間を省き、
　自動で最新のチャット画面が表示されるようにする）

# How it works 
「一つの画面でメッセージ送信　→もう一方の画面でメッセージが自動更新で表示される」
https://gyazo.com/088fff99b7e928634317772cf563aa4b